### PR TITLE
fix: SAWarning: requiring to specify

### DIFF
--- a/sqlathanor/schema.py
+++ b/sqlathanor/schema.py
@@ -34,6 +34,8 @@ class Column(SerializationMixin, SA_Column):
 
     # pylint: disable=too-many-ancestors, W0223
 
+    inherit_cache = True
+
     def __init__(self, *args, **kwargs):
         """Construct a new ``Column`` object.
 
@@ -185,6 +187,8 @@ class RelationshipProperty(SA_RelationshipProperty):
 
     Public constructor is the :func:`sqlathanor.schema.relationship` function.
     """
+
+    inherit_cache = True
 
     def __init__(self,
                  argument,


### PR DESCRIPTION
Fixing the issue with #110.

I believe this may be a bug with SqlAlchemy when using a different base than the one defined by SQA itself... They get the attribute `inherit_cache` like: 

    inherit_cache = cls.__dict__.get("inherit_cache", None)

This returns `None` while just doing:

    cls.inherit_cache

Does return the `True` they are looking for.

The workaround I propose to `sqlathanor` is just to override the class variable in some `schema` classes to avoid those warnings.