### PR TITLE
(fix): use "deserialize_function" arg in parse_yaml

### DIFF
--- a/sqlathanor/utilities.py
+++ b/sqlathanor/utilities.py
@@ -382,7 +382,7 @@ def are_dicts_equivalent(*args, **kwargs):
 
 
 def parse_yaml(input_data,
-               deserialize_function = None,
+               deserialize_function = yaml.safe_load,
                **kwargs):
     """De-serialize YAML data into a Python :class:`dict <python:dict>` object.
 
@@ -390,14 +390,14 @@ def parse_yaml(input_data,
     :type input_data: :class:`str <python:str>` / Path-like object
 
     :param deserialize_function: Optionally override the default YAML deserializer.
-      Defaults to :obj:`None <python:None>`, which calls the default ``yaml.safe_load()``
-      function from the `PyYAML <https://github.com/yaml/pyyaml>`_ library.
+      Defaults to :func:`yaml.safe_load <python:func>` from the 
+      `PyYAML <https://github.com/yaml/pyyaml>`_ library.
 
       .. note::
 
         Use the ``deserialize_function`` parameter to override the default
         YAML deserializer. A valid ``deserialize_function`` is expected to
-        accept a single :class:`str <python:str>` and return a
+        accept a single :class:`str <python:str>` or a file object and return a
         :class:`dict <python:dict>`, similar to ``yaml.safe_load()``.
 
         If you wish to pass additional arguments to your ``deserialize_function``
@@ -417,15 +417,10 @@ def parse_yaml(input_data,
     if checkers.is_file(input_data):
         is_file = True
 
-    if deserialize_function is None and not is_file:
-        deserialize_function = yaml.safe_load
-    elif deserialize_function is None and is_file:
-        deserialize_function = yaml.safe_load
-    else:
-        if checkers.is_callable(deserialize_function) is False:
-            raise ValueError(
-                'deserialize_function (%s) is not callable' % deserialize_function
-            )
+    if checkers.is_callable(deserialize_function) is False:
+        raise ValueError(
+            'deserialize_function (%s) is not callable' % deserialize_function
+        )
 
     if not input_data:
         raise DeserializationError('input_data is empty')
@@ -437,10 +432,10 @@ def parse_yaml(input_data,
         raise DeserializationError('input_data is not a valid string')
 
     if not is_file:
-        from_yaml = yaml.safe_load(input_data, **kwargs)
+        from_yaml = deserialize_function(input_data, **kwargs)
     else:
         with open(input_data, 'r') as input_file:
-            from_yaml = yaml.safe_load(input_file, **kwargs)
+            from_yaml = deserialize_function(input_file, **kwargs)
 
     return from_yaml
 


### PR DESCRIPTION
Hi team, 

I noticed that this arg in `parse_yaml` wasn't being used and since PyYAML doesn't support YAML > 1.2, I'd like to use `ruamel.yaml.load` in it's place.  Here's my fix - let me know what you think.

Cheers!